### PR TITLE
B-13531 - Add Makefile for alphabetical-company-search-consumer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,46 @@
+.PHONY: all
+all: build
+
+.PHONY: clean
+clean:
+	mvn clean
+
+.PHONY: build
+build:
+	mvn compile
+
+.PHONY: test
+test: test-unit
+
+.PHONY: test-unit
+test-unit:
+	mvn test
+
+.PHONY: package
+package:
+ifndef version
+	$(error No version given. Aborting)
+endif
+	$(info Packaging version: $(version))
+	mvn versions:set -DnewVersion=$(version) -DgenerateBackupPoms=false
+	mvn package -DskipTests=true
+
+.PHONY: dist
+dist: clean package
+
+.PHONY: publish
+publish:
+	mvn jar:jar deploy:deploy
+
+.PHONY: sonar
+sonar:
+	mvn sonar:sonar
+
+.PHONY: sonar-pr-analysis
+sonar-pr-analysis:
+	mvn sonar:sonar -P sonar-pr-analysis
+
+.PHONY: security-check
+security-check:
+	mvn org.owasp:dependency-check-maven:update-only
+	mvn org.owasp:dependency-check-maven:check -DfailBuildOnCVSS=4 -DassemblyAnalyzerEnabled=false


### PR DESCRIPTION
Build failing in pipeline - added Makefile as per reading guidance [here ](https://companieshouse.atlassian.net/wiki/spaces/DEVOPS/pages/1122238974/Quick-start+guide+to+creating+and+deploying+a+simple+Concourse+pipeline#Quick-startguidetocreatinganddeployingasimpleConcoursepipeline-Makefile)

Fulfils [BI-13531](https://companieshouse.atlassian.net/browse/BI-13531)

[BI-13531]: https://companieshouse.atlassian.net/browse/BI-13531?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ