### PR TITLE
BI-13531 - Add test-integration task to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,10 @@ test: test-unit
 test-unit:
 	mvn test
 
+.PHONY: test-integration
+test-integration: clean
+	mvn test -Dgroups="unit-test, integration-test"
+
 .PHONY: package
 package:
 ifndef version


### PR DESCRIPTION
[build-test-integration](https://ci-platform.companieshouse.gov.uk/teams/team-development/pipelines/alphabetical-company-search-consumer/jobs/build-test-integration) job failing in pipeline due to missing target 'test-integration' 

As per readme for [ci-concourse-resources](https://github.com/companieshouse/ci-concourse-resources/tree/shared-services/tasks/java/21/corretto/build-test-integration), adding a test-integration task to Makefile