### PR TITLE
BI-13524: Configure app as cidev streaming consumer

### DIFF
--- a/terraform/groups/ecs-service/profiles/development-eu-west-2/cidev/vars
+++ b/terraform/groups/ecs-service/profiles/development-eu-west-2/cidev/vars
@@ -3,4 +3,14 @@ aws_profile = "development-eu-west-2"
 
 # service configs
 log_level = "debug"
+human_log = "1"
+
+backoff_delay = "30000"
+bootstrap_server_url = "kafka-streaming-broker1-cidev.development.aws.internal:9092"
+concurrent_listener_instances = "1"
+group_id = "alphabetical-company-search-consumer-group"
+max_attempts = "4"
+server_port = "8080"
+topic = "stream-company-profile"
+
 use_set_environment_files = true


### PR DESCRIPTION
* Configure values for the environment variables required to be able to run the application as a `cidev` streaming cluster Kafka consumer.