### PR TITLE
BI-13524: Restore package zip file creation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+artifact_name       := alphabetical-company-search-consumer
+version             := unversioned
+
 .PHONY: all
 all: build
 
@@ -28,6 +31,10 @@ endif
 	$(info Packaging version: $(version))
 	mvn versions:set -DnewVersion=$(version) -DgenerateBackupPoms=false
 	mvn package -DskipTests=true
+	$(eval tmpdir:=$(shell mktemp -d build-XXXXXXXXXX))
+	cp ./target/$(artifact_name)-$(version).jar $(tmpdir)/$(artifact_name).jar
+	cd $(tmpdir); zip -r ../$(artifact_name)-$(version).zip *
+	rm -rf $(tmpdir)
 
 .PHONY: dist
 dist: clean package


### PR DESCRIPTION
* Restore the step that creates a zip file as part of the `package` target.
* This will hopefully resolve the issue seen affecting the `build-release` Concourse job for the `alphabetical-company-search-consumer` as can be seen in [this build](https://ci-platform.companieshouse.gov.uk/teams/team-development/pipelines/alphabetical-company-search-consumer/jobs/build-release/builds/7) for example:

> make: Leaving directory '/tmp/build/7011d2f2/source-code'
> cp: cannot stat 'source-code/*.zip': No such file or directory
 