### PR TITLE
BI-13535: Add non-sensitive consumer config variables

### DIFF
--- a/terraform/groups/ecs-service/profiles/live-eu-west-2/live/vars
+++ b/terraform/groups/ecs-service/profiles/live-eu-west-2/live/vars
@@ -1,8 +1,8 @@
-environment = "cidev"
-aws_profile = "development-eu-west-2"
+environment = "live"
+aws_profile = "live-eu-west-2"
 
 # service configs
-log_level = "debug"
+log_level = "trace"
 human_log = "1"
 
 backoff_delay = "30000"

--- a/terraform/groups/ecs-service/profiles/staging-eu-west-2/staging/vars
+++ b/terraform/groups/ecs-service/profiles/staging-eu-west-2/staging/vars
@@ -2,5 +2,14 @@ environment = "staging"
 aws_profile = "staging-eu-west-2"
 
 # service configs
-use_set_environment_files = true
 log_level = "trace"
+human_log = "1"
+
+backoff_delay = "30000"
+concurrent_listener_instances = "1"
+group_id = "alphabetical-company-search-consumer-group"
+max_attempts = "4"
+server_port = "8080"
+topic = "stream-company-profile"
+
+use_set_environment_files = true


### PR DESCRIPTION
* Configure all non-sensitive Kafka consumer environment variables for the app in plain text in static vars files for the `cidev`, `staging` and `live` environments. 
