### PR TITLE
BI-13535: Correct vpc_name reference, assuming this will be a service secret

### DIFF
--- a/terraform/groups/ecs-service/data.tf
+++ b/terraform/groups/ecs-service/data.tf
@@ -13,7 +13,7 @@ data "vault_generic_secret" "service_secrets" {
 data "aws_vpc" "vpc" {
   filter {
     name   = "tag:Name"
-    values = [local.vpc_name]
+    values = [local.parameter_store_secrets.vpc_name]
   }
 }
 


### PR DESCRIPTION
* We have decided that the `vpc_name` will (for now) be a secret held in a specific vault set up for this service, as is already reflected by this terraform:
```
  parameter_store_secrets = {
      "bootstrap_server_url" = local.service_secrets["bootstrap_server_url"]
      "vpc_name"             = local.service_secrets["vpc_name"]
  }
```
* To be consistent with this arrangement, we need to scope the `vpc_name` to the `parameter_store_secrets` block when referring to it.