### PR TITLE
BI-13535: Declare app config variables in the root module

### DIFF
--- a/terraform/groups/ecs-service/variables.tf
+++ b/terraform/groups/ecs-service/variables.tf
@@ -15,6 +15,47 @@ variable "aws_profile" {
   type        = string
   description = "The AWS profile to use for deployment."
 }
+variable "human_log" {
+  default     = 0
+  type        = number
+  description = "Where human-friendly logging is enabled or not."
+}
+
+# Kafka consumer configuration
+variable "backoff_delay" {
+  default   = 30000
+  type      = number
+  description = "The delay in milliseconds between message republish attempts."
+}
+variable "bootstrap_server_url" {
+  type      = string
+  description = "The URLs of the Kafka brokers that the consumers will connect to."
+}
+variable "concurrent_listener_instances" {
+  default   = 1
+  type      = number
+  description = "The number of consumers that should participate in the consumer group. Must be equal to the number of main topic partitions."
+}
+variable "group_id" {
+  default   = "alphabetical-company-search-consumer-group"
+  type      = string
+  description = "The group ID of the main consumer."
+}
+variable "max_attempts" {
+  default   = 4
+  type      = number
+  description = "The maximum number of times messages will be processed before they are sent to the dead letter topic."
+}
+variable "server_port" {
+    default   = 8080
+    type      = number
+    description = "Port this application runs on."
+}
+variable "topic" {
+  default   = "stream-company-profile"
+  type      = string
+  description = "The topic from which the main consumer will consume messages."
+}
 
 # ------------------------------------------------------------------------------
 # Docker Container


### PR DESCRIPTION
* This should mean we will no longer see warnings about using undeclared variables like the following:

```
╷
│ Warning: Value for undeclared variable
│ 
│ The root module does not declare a variable named "concurrent_listener_instances" but a value was found in file "/tmp/build/06e56704/terraform-code/terraform/groups/ecs-service/profiles/development-eu-west-2/cidev/vars". If you meant to use this value, add a "variable" block to the configuration.
│ 
│ To silence these warnings, use TF_VAR_... environment variables to provide certain "global" settings to all configurations in your organization. To reduce the verbosity of these warnings, use the -compact-warnings option.
```