### PR TITLE
BI-13535: Provide an empty default value for bootstrap_server_url

### DIFF
--- a/terraform/groups/ecs-service/variables.tf
+++ b/terraform/groups/ecs-service/variables.tf
@@ -28,6 +28,7 @@ variable "backoff_delay" {
   description = "The delay in milliseconds between message republish attempts."
 }
 variable "bootstrap_server_url" {
+  default   = ""
   type      = string
   description = "The URLs of the Kafka brokers that the consumers will connect to."
 }


### PR DESCRIPTION
* Do so in case the absence of this required variable is resulting in an error that hides other errors.
* Currently with no value provided we see this validation error only:

```
╷
│ Error: No value for required variable
│ 
│   on variables.tf line 30:
│   30: variable "bootstrap_server_url" {
│ 
│ The root module input variable "bootstrap_server_url" is not set, and has no default value. Use a -var or -var-file command line argument to provide a value for this variable.
╵
```