### PR TITLE
BI-13535: Move non-sensitive variables to .env files

### DIFF
--- a/terraform/groups/ecs-service/profiles/development-eu-west-2/cidev/vars
+++ b/terraform/groups/ecs-service/profiles/development-eu-west-2/cidev/vars
@@ -1,15 +1,4 @@
 environment = "cidev"
 aws_profile = "development-eu-west-2"
 
-# service configs
-log_level = "debug"
-human_log = "1"
-
-backoff_delay = "30000"
-concurrent_listener_instances = "1"
-group_id = "alphabetical-company-search-consumer-group"
-max_attempts = "4"
-server_port = "8080"
-topic = "stream-company-profile"
-
 use_set_environment_files = true

--- a/terraform/groups/ecs-service/profiles/live-eu-west-2/live/vars
+++ b/terraform/groups/ecs-service/profiles/live-eu-west-2/live/vars
@@ -1,15 +1,4 @@
 environment = "live"
 aws_profile = "live-eu-west-2"
 
-# service configs
-log_level = "trace"
-human_log = "1"
-
-backoff_delay = "30000"
-concurrent_listener_instances = "1"
-group_id = "alphabetical-company-search-consumer-group"
-max_attempts = "4"
-server_port = "8080"
-topic = "stream-company-profile"
-
 use_set_environment_files = true

--- a/terraform/groups/ecs-service/profiles/staging-eu-west-2/staging/vars
+++ b/terraform/groups/ecs-service/profiles/staging-eu-west-2/staging/vars
@@ -1,15 +1,4 @@
 environment = "staging"
 aws_profile = "staging-eu-west-2"
 
-# service configs
-log_level = "trace"
-human_log = "1"
-
-backoff_delay = "30000"
-concurrent_listener_instances = "1"
-group_id = "alphabetical-company-search-consumer-group"
-max_attempts = "4"
-server_port = "8080"
-topic = "stream-company-profile"
-
 use_set_environment_files = true


### PR DESCRIPTION
* We have been advised that best practice is to place non-sensitive variables in a `.env` file for the application, rather than to specify the variables in a `vars` file in the app's terraform.
* Hence, this PR removes the app config variables that will instead be placed in new `alphabetical-company-search-consumer.env` files, such as the one seen in [this other PR](https://github.com/companieshouse/ecs-service-configs-dev/pull/145).

**DO NOT MERGE THIS PR** until the corresponding `.env` files have been created and populated with the corresponding variable definitions for all 3 `cidev`, `staging` and `live` environments.

