### PR TITLE
BI-13535: Rename block to reflect where secret variables are held

### DIFF
--- a/terraform/groups/ecs-service/data.tf
+++ b/terraform/groups/ecs-service/data.tf
@@ -13,7 +13,7 @@ data "vault_generic_secret" "service_secrets" {
 data "aws_vpc" "vpc" {
   filter {
     name   = "tag:Name"
-    values = [local.parameter_store_secrets.vpc_name]
+    values = [local.service_vault_secrets.vpc_name]
   }
 }
 

--- a/terraform/groups/ecs-service/locals.tf
+++ b/terraform/groups/ecs-service/locals.tf
@@ -20,7 +20,7 @@ locals {
   stack_secrets   = jsondecode(data.vault_generic_secret.stack_secrets.data_json)
   service_secrets = jsondecode(data.vault_generic_secret.service_secrets.data_json)
 
-  parameter_store_secrets = {
+  service_vault_secrets = {
       "bootstrap_server_url" = local.service_secrets["bootstrap_server_url"]
       "vpc_name"             = local.service_secrets["vpc_name"]
   }

--- a/terraform/groups/ecs-service/main.tf
+++ b/terraform/groups/ecs-service/main.tf
@@ -24,7 +24,7 @@ module "secrets" {
   name_prefix = "${local.service_name}-${var.environment}"
   environment = var.environment
   kms_key_id  = data.aws_kms_key.kms_key.id
-  secrets     = local.parameter_store_secrets
+  secrets     = local.service_vault_secrets
 }
 
 module "ecs-service" {


### PR DESCRIPTION
* Given we are storing secret variables in a service vault, the name `parameter_store_secrets` is no longer appropriate, and indeed is misleading.
* This changes the block name to the more accurate `service_vault_secrets`.