### PR TITLE
BI-13535: Correct configuration affecting healthcheck endpoint

### DIFF
--- a/terraform/groups/ecs-service/locals.tf
+++ b/terraform/groups/ecs-service/locals.tf
@@ -7,14 +7,14 @@ locals {
   container_port             = 8080
   docker_repo                = "alphabetical-company-search-consumer"
   kms_alias                  = "alias/${var.aws_profile}/environment-services-kms"
-  lb_listener_rule_priority  = 21
-  lb_listener_paths          = []
   s3_config_bucket           = data.vault_generic_secret.shared_s3.data["config_bucket_name"]
   app_environment_filename   = "alphabetical-company-search-consumer.env"
   use_set_environment_files  = var.use_set_environment_files
   application_subnet_ids     = data.aws_subnets.application.ids
   application_subnet_pattern = local.stack_secrets["application_subnet_pattern"]
-  healthcheck_path           = "/healthcheck" #healthcheck path for alphabetical-company-search-consumer service
+  lb_listener_rule_priority  = 21
+  lb_listener_paths          = ["/alphabetical-company-search-consumer/*"]
+  healthcheck_path           = "/alphabetical-company-search-consumer/healthcheck" #healthcheck path for alphabetical-company-search-consumer service
   healthcheck_matcher        = "200"
 
   stack_secrets   = jsondecode(data.vault_generic_secret.stack_secrets.data_json)


### PR DESCRIPTION
This error was seen when the [cidev-apply job was executed](https://ci-platform.companieshouse.gov.uk/teams/team-development/pipelines/alphabetical-company-search-consumer/jobs/cidev-apply/builds/1):

```╷
│ Error: creating ECS Service (cidev-alphabetical-company-search-consumer): InvalidParameterException: The target group with targetGroupArn arn:aws:elasticloadbalancing:eu-west-2:169942020521:targetgroup/cidev-alphabetical-company-s-far/e12b6381b39b1230 does not have an associated load balancer.
│ 
│   with module.ecs-service.aws_ecs_service.ecs-service,
│   on .terraform/modules/ecs-service/aws/ecs/ecs-service/ecs-service.tf line 1, in resource "aws_ecs_service" "ecs-service":
│    1: resource "aws_ecs_service" "ecs-service" {
│ 
```

Hence, try:

1. correcting path to healthcheck endpoint to match that the app serves the endpoint on
2. adding the path to those routed via the load balancer