### PR TITLE
BI-13535: Correct load balancer configuration

### DIFF
--- a/terraform/groups/ecs-service/data.tf
+++ b/terraform/groups/ecs-service/data.tf
@@ -42,6 +42,15 @@ data "aws_lb_listener" "service_lb_listener" {
   port = 443
 }
 
+data "aws_lb" "secondary_lb" {
+  name = "${var.environment}-chs-apichgovuk-private"
+}
+
+data "aws_lb_listener" "secondary_lb_listener" {
+  load_balancer_arn = data.aws_lb.secondary_lb.arn
+  port = 443
+}
+
 # retrieve all secrets for this stack using the stack path
 data "aws_ssm_parameters_by_path" "secrets" {
   path = "/${local.name_prefix}"

--- a/terraform/groups/ecs-service/data.tf
+++ b/terraform/groups/ecs-service/data.tf
@@ -34,7 +34,7 @@ data "aws_iam_role" "ecs_cluster_iam_role" {
 }
 
 data "aws_lb" "service_lb" {
-  name = "${var.environment}-chs-accountchgovuk"
+  name = "${var.environment}-chs-apichgovuk"
 }
 
 data "aws_lb_listener" "service_lb_listener" {

--- a/terraform/groups/ecs-service/main.tf
+++ b/terraform/groups/ecs-service/main.tf
@@ -42,6 +42,12 @@ module "ecs-service" {
   lb_listener_arn           = data.aws_lb_listener.service_lb_listener.arn
   lb_listener_rule_priority = local.lb_listener_rule_priority
   lb_listener_paths         = local.lb_listener_paths
+  multilb_listeners               = {
+    "priv-api-lb": {
+      listener_arn           = data.aws_lb_listener.secondary_lb_listener.arn,
+      load_balancer_arn      = data.aws_lb.secondary_lb.arn
+    }
+  }
 
   # ECS Task container health check
   use_task_container_healthcheck = true


### PR DESCRIPTION
* As per the guidance provided in [this slack chat](https://companieshouse.slack.com/archives/C02TZ3RCGG5/p1709021817776419).
* Attach the app to the public API ALB site rather than the accounts ALB site.
* Provide internal routing for app traffic.