### PR TITLE
BI-13603: Avoid or suppress security vulnerabilities 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,6 +137,18 @@
             <artifactId>jackson-databind</artifactId>
             <version>2.16.0</version>
         </dependency>
+        <!-- Avoid potential security vulnerability CVE-2024-22243. -->
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
+            <version>6.1.4</version>
+        </dependency>
+        <!-- Avoid potential security vulnerabilities CVE-2024-26308 and CVE-2024-25710. -->
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+            <version>1.26.0</version>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/suppress.xml
+++ b/suppress.xml
@@ -1,3 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+    <suppress>
+        <notes><![CDATA[
+   file name: http2-common-11.0.19.jar
+   This Spring Boot app uses Tomcat, not Jetty, hence the vulnerable code does not come into use.
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.eclipse\.jetty\.http2/http2\-common@.*$
+        </packageUrl>
+        <vulnerabilityName>CVE-2024-22201</vulnerabilityName>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
* Avoid 3 of the 4 vulnerabilities currently reported by upgrading the dependency that brought them in.
* Suppress the alert for the 4th, as it seems it should not apply as it lies in code the app will not execute.