### PR TITLE
BI-13691 update auto offset reset to use latest

### DIFF
--- a/src/main/java/uk/gov/companieshouse/alphabeticalcompanysearchconsumer/config/Config.java
+++ b/src/main/java/uk/gov/companieshouse/alphabeticalcompanysearchconsumer/config/Config.java
@@ -64,7 +64,7 @@ public class Config {
                 ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class,
                 ErrorHandlingDeserializer.KEY_DESERIALIZER_CLASS, StringDeserializer.class,
                 ErrorHandlingDeserializer.VALUE_DESERIALIZER_CLASS, StringDeserializer.class,
-                ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest",
+                ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest",
                 ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false"),
             new StringDeserializer(),
             new ErrorHandlingDeserializer<>(new AvroDeserializer<>(ResourceChangedData.class)));

--- a/src/test/java/uk/gov/companieshouse/alphabeticalcompanysearchconsumer/config/TestKafkaConfig.java
+++ b/src/test/java/uk/gov/companieshouse/alphabeticalcompanysearchconsumer/config/TestKafkaConfig.java
@@ -42,7 +42,7 @@ public class TestKafkaConfig {
                 ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers,
                 ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class,
                 ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class,
-                ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest",
+                ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest",
                 ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false",
                 ConsumerConfig.GROUP_ID_CONFIG, UUID.randomUUID().toString()),
             new StringDeserializer(), new AvroDeserializer<>(ResourceChangedData.class));


### PR DESCRIPTION
Updates the atuo offset reset config value to use 'latest' which starts reading from the latest message in the partition, ignoring all previous messages if there is no previously committed offset.