### PR TITLE
DSND-2980: Increase/add default backoff delay to be inline with configs

### DIFF
--- a/terraform/groups/ecs-service/variables.tf
+++ b/terraform/groups/ecs-service/variables.tf
@@ -23,7 +23,7 @@ variable "human_log" {
 
 # Kafka consumer configuration
 variable "backoff_delay" {
-  default   = 30000
+  default   = 31000
   type      = number
   description = "The delay in milliseconds between message republish attempts."
 }


### PR DESCRIPTION
[DSND-2980](https://companieshouse.atlassian.net/browse/DSND-2980)

[DSND-2980]: https://companieshouse.atlassian.net/browse/DSND-2980?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ