### PR TITLE
staging/live Increase CPU, memory and scale out values

### DIFF
--- a/terraform/groups/ecs-service/profiles/live-eu-west-2/live/vars
+++ b/terraform/groups/ecs-service/profiles/live-eu-west-2/live/vars
@@ -2,3 +2,7 @@ environment = "live"
 aws_profile = "live-eu-west-2"
 
 use_set_environment_files = true
+
+required_cpus = 512
+required_memory = 1024
+service_autoscale_scale_out_cooldown = 600

--- a/terraform/groups/ecs-service/profiles/staging-eu-west-2/staging/vars
+++ b/terraform/groups/ecs-service/profiles/staging-eu-west-2/staging/vars
@@ -7,3 +7,7 @@ use_set_environment_files = true
 service_autoscale_enabled  = true
 service_scaledown_schedule = "55 19 * * ? *"
 service_scaleup_schedule   = "5 6 * * ? *"
+
+required_cpus = 512
+required_memory = 1024
+service_autoscale_scale_out_cooldown = 600


### PR DESCRIPTION
Increase cpu memory and scale out values to attempt to prevent constant recycling and timeouts to give the service longer to reach a healthy state and to avoid potentially timing out on `apply` jobs. 